### PR TITLE
Support arbitrary training criteria

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,6 +34,9 @@ Example
       estimator=base_estimator,               # here is your deep learning model
       n_estimators=10,                        # number of base estimators
   )
+  # Set the criterion
+  criterion = nn.CrossEntropyLoss()           # training objective
+  ensemble.set_criterion(criterion)
 
   # Set the optimizer
   ensemble.set_optimizer(

--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -82,6 +82,17 @@ The meaning of different arguments is listed as follow:
 * ``n_estimators``: The number of base estimators in the ensemble.
 * ``cuda``: Specify whether to use GPU for training and evaluating the ensemble.
 
+Set the Criterion
+-----------------
+
+The next step is to set the objective function. Since our ensemble model is a classifier, we 
+will use cross-entropy:
+
+.. code-block:: python
+
+    criterion = nn.CrossEntropyLoss()
+    model.set_criterion(criterion)
+
 Set the Optimizer
 -----------------
 
@@ -179,6 +190,10 @@ The script below shows an example on using VotingClassifier with 10 MLPs for cla
         n_estimators=10,
         cuda=True,
     )
+
+    # Set the criterion
+    criterion = nn.CrossEntropyLoss()
+    model.set_criterion(criterion)
 
     # Set the optimizer
     model.set_optimizer('Adam', lr=1e-3, weight_decay=5e-4)

--- a/torchensemble/_base.py
+++ b/torchensemble/_base.py
@@ -137,6 +137,10 @@ class BaseModule(nn.Module):
             self.logger.error(msg.format(log_interval))
             raise ValueError(msg.format(log_interval))
 
+    def set_criterion(self, criterion):
+        """Set the training criterion."""
+        self._criterion = criterion
+    
     def set_optimizer(self, optimizer_name, **kwargs):
         """Set the parameter optimizer."""
         self.optimizer_name = optimizer_name
@@ -226,7 +230,6 @@ class BaseClassifier(BaseModule):
         self.eval()
         correct = 0
         total = 0
-        criterion = nn.CrossEntropyLoss()
         loss = 0.0
 
         for _, elem in enumerate(test_loader):
@@ -235,7 +238,7 @@ class BaseClassifier(BaseModule):
             _, predicted = torch.max(output.data, 1)
             correct += (predicted == target).sum().item()
             total += target.size(0)
-            loss += criterion(output, target)
+            loss += self._criterion(output, target)
 
         acc = 100 * correct / total
         loss /= len(test_loader)
@@ -273,12 +276,11 @@ class BaseRegressor(BaseModule):
     def evaluate(self, test_loader):
         """Docstrings decorated by downstream ensembles."""
         self.eval()
-        mse = 0.0
-        criterion = nn.MSELoss()
+        loss = 0.0
 
         for _, elem in enumerate(test_loader):
             data, target = split_data_target(elem, self.device)
             output = self.forward(*data)
-            mse += criterion(output, target)
+            loss += self._criterion(output, target)
 
-        return float(mse) / len(test_loader)
+        return float(loss) / len(test_loader)

--- a/torchensemble/bagging.py
+++ b/torchensemble/bagging.py
@@ -158,7 +158,6 @@ class BaggingClassifier(BaseClassifier):
             )
 
         # Utils
-        criterion = nn.CrossEntropyLoss()
         best_acc = 0.0
 
         # Internal helper function on pesudo forward
@@ -192,7 +191,7 @@ class BaggingClassifier(BaseClassifier):
                         estimator,
                         cur_lr,
                         optimizer,
-                        criterion,
+                        self._criterion,
                         idx,
                         epoch,
                         log_interval,
@@ -330,8 +329,7 @@ class BaggingRegressor(BaseRegressor):
             )
 
         # Utils
-        criterion = nn.MSELoss()
-        best_mse = float("inf")
+        best_loss = float("inf")
 
         # Internal helper function on pesudo forward
         def _forward(estimators, *x):
@@ -362,7 +360,7 @@ class BaggingRegressor(BaseRegressor):
                         estimator,
                         cur_lr,
                         optimizer,
-                        criterion,
+                        self._criterion,
                         idx,
                         epoch,
                         log_interval,
@@ -383,30 +381,30 @@ class BaggingRegressor(BaseRegressor):
                 if test_loader:
                     self.eval()
                     with torch.no_grad():
-                        mse = 0.0
+                        val_loss = 0.0
                         for _, elem in enumerate(test_loader):
                             data, target = io.split_data_target(
                                 elem, self.device
                             )
                             output = _forward(estimators, *data)
-                            mse += criterion(output, target)
-                        mse /= len(test_loader)
+                            val_loss += self._criterion(output, target)
+                        val_loss /= len(test_loader)
 
-                        if mse < best_mse:
-                            best_mse = mse
+                        if val_loss < best_loss:
+                            best_loss = val_loss
                             self.estimators_ = nn.ModuleList()
                             self.estimators_.extend(estimators)
                             if save_model:
                                 io.save(self, save_dir, self.logger)
 
                         msg = (
-                            "Epoch: {:03d} | Validation MSE:"
+                            "Epoch: {:03d} | Validation Loss:"
                             " {:.5f} | Historical Best: {:.5f}"
                         )
-                        self.logger.info(msg.format(epoch, mse, best_mse))
+                        self.logger.info(msg.format(epoch, val_loss, best_loss))
                         if self.tb_logger:
                             self.tb_logger.add_scalar(
-                                "bagging/Validation_MSE", mse, epoch
+                                "bagging/Validation_Loss", val_loss, epoch
                             )
 
                 # Update the scheduler

--- a/torchensemble/tests/test_adversarial_training.py
+++ b/torchensemble/tests/test_adversarial_training.py
@@ -36,7 +36,8 @@ def test_adversarial_training_range():
     model = torchensemble.AdversarialTrainingClassifier(
         estimator=MLP_clf, n_estimators=2, cuda=False
     )
-
+    criterion = nn.CrossEntropyLoss()
+    model.set_criterion(criterion)
     model.set_optimizer("Adam")
 
     # Prepare data

--- a/torchensemble/tests/test_all_models.py
+++ b/torchensemble/tests/test_all_models.py
@@ -95,6 +95,10 @@ def test_clf_class(clf):
 
     model = clf(estimator=MLP_clf, n_estimators=n_estimators, cuda=False)
 
+    # Criterion
+    criterion = nn.CrossEntropyLoss()
+    model.set_criterion(criterion)
+
     # Optimizer
     model.set_optimizer("Adam", lr=1e-3, weight_decay=5e-4)
 
@@ -143,6 +147,10 @@ def test_clf_object(clf):
     n_estimators = 2
 
     model = clf(estimator=MLP_clf(), n_estimators=n_estimators, cuda=False)
+
+    # Criterion
+    criterion = nn.CrossEntropyLoss()
+    model.set_criterion(criterion)
 
     # Optimizer
     model.set_optimizer("Adam", lr=1e-3, weight_decay=5e-4)
@@ -193,6 +201,10 @@ def test_reg_class(reg):
 
     model = reg(estimator=MLP_reg, n_estimators=n_estimators, cuda=False)
 
+    # Criterion
+    criterion = nn.MSELoss()
+    model.set_criterion(criterion)
+
     # Optimizer
     model.set_optimizer("Adam", lr=1e-3, weight_decay=5e-4)
 
@@ -242,6 +254,10 @@ def test_reg_object(reg):
 
     model = reg(estimator=MLP_reg(), n_estimators=n_estimators, cuda=False)
 
+    # Criterion
+    criterion = nn.MSELoss()
+    model.set_criterion(criterion)
+
     # Optimizer
     model.set_optimizer("Adam", lr=1e-3, weight_decay=5e-4)
 
@@ -285,6 +301,7 @@ def test_predict():
 
     fusion = all_clf[0]  # FusionClassifier
     model = fusion(estimator=MLP_clf, n_estimators=2, cuda=False)
+    model.set_criterion(nn.CrossEntropyLoss())
     model.set_optimizer("Adam", lr=1e-3, weight_decay=5e-4)
 
     train = TensorDataset(X_train, y_train_clf)

--- a/torchensemble/tests/test_all_models_multi_input.py
+++ b/torchensemble/tests/test_all_models_multi_input.py
@@ -101,6 +101,10 @@ def test_clf_class(clf):
 
     model = clf(estimator=MLP_clf, n_estimators=n_estimators, cuda=False)
 
+    # Criterion
+    criterion = nn.CrossEntropyLoss()
+    model.set_criterion(criterion)
+    
     # Optimizer
     model.set_optimizer("Adam", lr=1e-3, weight_decay=5e-4)
 
@@ -152,6 +156,10 @@ def test_clf_object(clf):
 
     model = clf(estimator=MLP_clf(), n_estimators=n_estimators, cuda=False)
 
+    # Criterion
+    criterion = nn.CrossEntropyLoss()
+    model.set_criterion(criterion)
+    
     # Optimizer
     model.set_optimizer("Adam", lr=1e-3, weight_decay=5e-4)
 
@@ -203,6 +211,10 @@ def test_reg_class(reg):
 
     model = reg(estimator=MLP_reg, n_estimators=n_estimators, cuda=False)
 
+    # Criterion
+    criterion = nn.MSELoss()
+    model.set_criterion(criterion)
+    
     # Optimizer
     model.set_optimizer("Adam", lr=1e-3, weight_decay=5e-4)
 
@@ -254,6 +266,10 @@ def test_reg_object(reg):
 
     model = reg(estimator=MLP_reg(), n_estimators=n_estimators, cuda=False)
 
+    # Criterion
+    criterion = nn.MSELoss()
+    model.set_criterion(criterion)
+    
     # Optimizer
     model.set_optimizer("Adam", lr=1e-3, weight_decay=5e-4)
 

--- a/torchensemble/tests/test_tb_logging.py
+++ b/torchensemble/tests/test_tb_logging.py
@@ -94,6 +94,10 @@ def test_clf_class(clf):
 
     model = clf(estimator=MLP_clf, n_estimators=n_estimators, cuda=False)
 
+    # Criterion
+    criterion = nn.CrossEntropyLoss()
+    model.set_criterion(criterion)
+
     # Optimizer
     model.set_optimizer("Adam", lr=1e-3, weight_decay=5e-4)
 
@@ -142,6 +146,10 @@ def test_clf_object(clf):
     n_estimators = 2
 
     model = clf(estimator=MLP_clf(), n_estimators=n_estimators, cuda=False)
+
+    # Criterion
+    criterion = nn.CrossEntropyLoss()
+    model.set_criterion(criterion)
 
     # Optimizer
     model.set_optimizer("Adam", lr=1e-3, weight_decay=5e-4)
@@ -192,6 +200,10 @@ def test_reg_class(reg):
 
     model = reg(estimator=MLP_reg, n_estimators=n_estimators, cuda=False)
 
+    # Criterion
+    criterion = nn.MSELoss()
+    model.set_criterion(criterion)
+    
     # Optimizer
     model.set_optimizer("Adam", lr=1e-3, weight_decay=5e-4)
 
@@ -240,6 +252,10 @@ def test_reg_object(reg):
     n_estimators = 2
 
     model = reg(estimator=MLP_reg(), n_estimators=n_estimators, cuda=False)
+
+    # Criterion
+    criterion = nn.MSELoss()
+    model.set_criterion(criterion)
 
     # Optimizer
     model.set_optimizer("Adam", lr=1e-3, weight_decay=5e-4)

--- a/torchensemble/utils/io.py
+++ b/torchensemble/utils/io.py
@@ -28,6 +28,7 @@ def save(model, save_dir, logger):
     state = {
         "n_estimators": len(model.estimators_),
         "model": model.state_dict(),
+        "_criterion": model._criterion,
     }
     save_dir = os.path.join(save_dir, filename)
 
@@ -64,6 +65,7 @@ def load(model, save_dir="./", logger=None):
     state = torch.load(save_dir)
     n_estimators = state["n_estimators"]
     model_params = state["model"]
+    model._criterion = state["_criterion"]
 
     # Pre-allocate and load all base estimators
     for _ in range(n_estimators):


### PR DESCRIPTION
The training objective is now set using `model.set_crtierion(criterion)`, which sets the `_criterion` instance variable.

Approach:

- Added the `set_criterion` method to the `BaseModule` class in `_base.py`. 
- Removed the manual specification of the criterion in each ensemble module. Any previous calls to pre-set criteria are now done via `self._criterion`.
- Updated tensorboard logging names and validation print outs in the case of Regressors.
- All tests have been updated such that `set_criterion` is called when specifying a model in each test.
- In `utils/io.py`, added `"_criterion": model._criterion` to the state dict when saving. This is also loaded and set when loading a model.
- Docs: updated the index and quick start sections in the docs to include the new `set_criteiron` step.

Note:
In the case of GradientBoosting, `model.set_crtierion(criterion)` will have no effect and gradient boosting ensembles will function as they did previously with no changes.

Let me know if there is anything wrong with my changes or if I've missed anything. I'm happy to make any changes you think are necessary.

Batuhan
