### PR TITLE
fix readme example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ Example
     )
 
     # Evaluate the ensemble
-    acc = ensemble.predict(test_loader)         # testing accuracy
+    acc = ensemble.evaluate(test_loader)         # testing accuracy
 
 Supported Ensemble
 ------------------


### PR DESCRIPTION
ensemble.predict takes a tensor and returns the output feature, therefore it should be ensemble.evaluate, which takes a testloader and returns the accuracy.