### PR TITLE
initial attempt to implementing hard majority voting

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Changelog
 Ver 0.1.*
 ---------
 
+* |Feature| |API| Add ``voting_strategy`` parameter for :class:`VotingClassifer`, :class:`NeuralForestClassifier`, and :class:`SnapshotEnsembleClassifier` | `@LukasGardberg <https://github.com/LukasGardberg>`__
 * |Fix| Fix the sampling issue in :class:`BaggingClassifier` and :class:`BaggingRegressor` | `@SunHaozhe <https://github.com/SunHaozhe>`__
 * |Feature| |API| Add :class:`NeuralForestClassifier` and :class:`NeuralForestRegressor` | `@xuyxu <https://github.com/xuyxu>`__
 * |Fix| Relax check on input dataloader | `@xuyxu <https://github.com/xuyxu>`__

--- a/torchensemble/_base.py
+++ b/torchensemble/_base.py
@@ -280,8 +280,16 @@ class BaseClassifier(BaseModule):
 
         for _, elem in enumerate(test_loader):
             data, target = split_data_target(elem, self.device)
+
+            # Get averaged probabilities over all base estimators
+            # for each sample in batch.
+            # Output shape: (batch_size, n_classes)
             output = self.forward(*data)
+
+            # get val, idx for the class w max log-prob for each sample
+            # predicted shape: (batch_size)
             _, predicted = torch.max(output.data, 1)
+
             correct += (predicted == target).sum().item()
             total += target.size(0)
             loss += self._criterion(output, target)

--- a/torchensemble/_base.py
+++ b/torchensemble/_base.py
@@ -203,7 +203,7 @@ class BaseModule(nn.Module):
 class BaseTreeEnsemble(BaseModule):
     def __init__(
         self,
-        n_estimators,
+        n_estimators=10,
         depth=5,
         lamda=1e-3,
         cuda=False,

--- a/torchensemble/_base.py
+++ b/torchensemble/_base.py
@@ -281,13 +281,8 @@ class BaseClassifier(BaseModule):
         for _, elem in enumerate(test_loader):
             data, target = split_data_target(elem, self.device)
 
-            # Get averaged probabilities over all base estimators
-            # for each sample in batch.
-            # Output shape: (batch_size, n_classes)
             output = self.forward(*data)
 
-            # get val, idx for the class w max log-prob for each sample
-            # predicted shape: (batch_size)
             _, predicted = torch.max(output.data, 1)
 
             correct += (predicted == target).sum().item()
@@ -357,8 +352,8 @@ class BaseTree(nn.Module):
 
         self._validate_parameters()
 
-        self.internal_node_num_ = 2**self.depth - 1
-        self.leaf_node_num_ = 2**self.depth
+        self.internal_node_num_ = 2 ** self.depth - 1
+        self.leaf_node_num_ = 2 ** self.depth
 
         # Different penalty coefficients for nodes in different layers
         self.penalty_list = [
@@ -428,7 +423,7 @@ class BaseTree(nn.Module):
         penalty = torch.tensor(0.0).to(self.device)
 
         batch_size = _mu.size()[0]
-        _mu = _mu.view(batch_size, 2**layer_idx)
+        _mu = _mu.view(batch_size, 2 ** layer_idx)
         _path_prob = _path_prob.view(batch_size, 2 ** (layer_idx + 1))
 
         for node in range(0, 2 ** (layer_idx + 1)):

--- a/torchensemble/_base.py
+++ b/torchensemble/_base.py
@@ -357,8 +357,8 @@ class BaseTree(nn.Module):
 
         self._validate_parameters()
 
-        self.internal_node_num_ = 2 ** self.depth - 1
-        self.leaf_node_num_ = 2 ** self.depth
+        self.internal_node_num_ = 2**self.depth - 1
+        self.leaf_node_num_ = 2**self.depth
 
         # Different penalty coefficients for nodes in different layers
         self.penalty_list = [
@@ -428,7 +428,7 @@ class BaseTree(nn.Module):
         penalty = torch.tensor(0.0).to(self.device)
 
         batch_size = _mu.size()[0]
-        _mu = _mu.view(batch_size, 2 ** layer_idx)
+        _mu = _mu.view(batch_size, 2**layer_idx)
         _path_prob = _path_prob.view(batch_size, 2 ** (layer_idx + 1))
 
         for node in range(0, 2 ** (layer_idx + 1)):

--- a/torchensemble/snapshot_ensemble.py
+++ b/torchensemble/snapshot_ensemble.py
@@ -209,7 +209,6 @@ class _BaseSnapshotEnsemble(BaseModule):
     """Implementation on the SnapshotEnsembleClassifier.""", "seq_model"
 )
 class SnapshotEnsembleClassifier(_BaseSnapshotEnsemble, BaseClassifier):
-
     def __init__(self, voting_strategy="soft", **kwargs):
         super().__init__(**kwargs)
 

--- a/torchensemble/tests/test_operator.py
+++ b/torchensemble/tests/test_operator.py
@@ -43,3 +43,14 @@ def test_residual_regression_invalid_shape():
             label.view(-1, 1),  # 4 * 1
         )
     assert "should be the same as output" in str(excinfo.value)
+
+
+def test_majority_voting():
+    outputs = [
+        torch.FloatTensor(np.array(([0.9, 0.1], [0.2, 0.8]))),
+        torch.FloatTensor(np.array(([0.7, 0.3], [0.1, 0.9]))),
+        torch.FloatTensor(np.array(([0.1, 0.9], [0.8, 0.2]))),
+    ]
+    actual = op.majority_vote(outputs).numpy() 
+    expected = np.array(([1, 0], [0, 1]))
+    assert_array_almost_equal(actual, expected)

--- a/torchensemble/tests/test_operator.py
+++ b/torchensemble/tests/test_operator.py
@@ -51,6 +51,6 @@ def test_majority_voting():
         torch.FloatTensor(np.array(([0.7, 0.3], [0.1, 0.9]))),
         torch.FloatTensor(np.array(([0.1, 0.9], [0.8, 0.2]))),
     ]
-    actual = op.majority_vote(outputs).numpy() 
+    actual = op.majority_vote(outputs).numpy()
     expected = np.array(([1, 0], [0, 1]))
     assert_array_almost_equal(actual, expected)

--- a/torchensemble/utils/operator.py
+++ b/torchensemble/utils/operator.py
@@ -3,6 +3,7 @@
 
 import torch
 import torch.nn.functional as F
+from typing import List
 
 
 __all__ = [
@@ -11,6 +12,7 @@ __all__ = [
     "onehot_encoding",
     "pseudo_residual_classification",
     "pseudo_residual_regression",
+    "majority_vote",
 ]
 
 
@@ -51,3 +53,18 @@ def pseudo_residual_regression(target, output):
         raise ValueError(msg.format(target.size(), output.size()))
 
     return target - output
+
+
+def majority_vote(outputs: List[torch.Tensor]) -> torch.Tensor:
+    """Compute the majority vote for a list of model outputs.
+    outputs: list of length (n_models) of tensors with shape (n_samples, n_classes)
+    majority_one_hots: (n_samples, n_classes)
+    """
+
+    assert len(outputs[0].shape) == 2, "The shape of outputs should be (n_models, n_samples, n_classes)."
+
+    votes = torch.stack(outputs).argmax(dim=2).mode(dim=0)[0]
+    proba = torch.zeros_like(outputs[0])
+    majority_one_hots = proba.scatter_(1, votes.view(-1, 1), 1)
+
+    return majority_one_hots

--- a/torchensemble/utils/operator.py
+++ b/torchensemble/utils/operator.py
@@ -57,7 +57,8 @@ def pseudo_residual_regression(target, output):
 
 def majority_vote(outputs: List[torch.Tensor]) -> torch.Tensor:
     """Compute the majority vote for a list of model outputs.
-    outputs: list of length (n_models) of tensors with shape (n_samples, n_classes)
+    outputs: list of length (n_models)
+    containing tensors with shape (n_samples, n_classes)
     majority_one_hots: (n_samples, n_classes)
     """
 

--- a/torchensemble/utils/operator.py
+++ b/torchensemble/utils/operator.py
@@ -63,8 +63,8 @@ def majority_vote(outputs: List[torch.Tensor]) -> torch.Tensor:
     """
 
     if len(outputs[0].shape) != 2:
-        msg = """The shape of outputs should be a list tensors of 
-        length (n_models) with sizes (n_samples, n_classes). 
+        msg = """The shape of outputs should be a list tensors of
+        length (n_models) with sizes (n_samples, n_classes).
         The first tensor had shape {} """
         raise ValueError(msg.format(outputs[0].shape))
 

--- a/torchensemble/utils/operator.py
+++ b/torchensemble/utils/operator.py
@@ -61,7 +61,9 @@ def majority_vote(outputs: List[torch.Tensor]) -> torch.Tensor:
     majority_one_hots: (n_samples, n_classes)
     """
 
-    assert len(outputs[0].shape) == 2, "The shape of outputs should be (n_models, n_samples, n_classes)."
+    assert (
+        len(outputs[0].shape) == 2
+    ), "The shape of outputs should be (n_models, n_samples, n_classes)."
 
     votes = torch.stack(outputs).argmax(dim=2).mode(dim=0)[0]
     proba = torch.zeros_like(outputs[0])

--- a/torchensemble/utils/operator.py
+++ b/torchensemble/utils/operator.py
@@ -62,9 +62,11 @@ def majority_vote(outputs: List[torch.Tensor]) -> torch.Tensor:
     majority_one_hots: (n_samples, n_classes)
     """
 
-    assert (
-        len(outputs[0].shape) == 2
-    ), "The shape of outputs should be (n_models, n_samples, n_classes)."
+    if len(outputs[0].shape) != 2:
+        msg = """The shape of outputs should be a list tensors of 
+        length (n_models) with sizes (n_samples, n_classes). 
+        The first tensor had shape {} """
+        raise ValueError(msg.format(outputs[0].shape))
 
     votes = torch.stack(outputs).argmax(dim=2).mode(dim=0)[0]
     proba = torch.zeros_like(outputs[0])

--- a/torchensemble/voting.py
+++ b/torchensemble/voting.py
@@ -92,7 +92,6 @@ def _parallel_fit_per_epoch(
     """Implementation on the VotingClassifier.""", "model"
 )
 class VotingClassifier(BaseClassifier):
-
     def __init__(self, voting_strategy="soft", **kwargs):
         super(VotingClassifier, self).__init__(**kwargs)
 
@@ -123,7 +122,8 @@ class VotingClassifier(BaseClassifier):
             F.softmax(estimator(*x), dim=1) for estimator in self.estimators_
         ]
 
-        if self.voting_strategy == "soft": proba = op.average(outputs)
+        if self.voting_strategy == "soft":
+            proba = op.average(outputs)
 
         elif self.voting_strategy == "hard":
             # Do hard majority voting
@@ -137,7 +137,7 @@ class VotingClassifier(BaseClassifier):
             # predict and evaluate
 
         # Returns averaged class probabilities for each sample
-        # proba shape: (batch_size, n_classes) 
+        # proba shape: (batch_size, n_classes)
         return proba
 
     @torchensemble_model_doc(
@@ -208,7 +208,8 @@ class VotingClassifier(BaseClassifier):
                 F.softmax(estimator(*x), dim=1) for estimator in estimators
             ]
 
-            if self.voting_strategy == "soft": proba = op.average(outputs)
+            if self.voting_strategy == "soft":
+                proba = op.average(outputs)
 
             # Maybe the voting strategy can be packaged as a function?
             elif self.voting_strategy == "hard":

--- a/torchensemble/voting.py
+++ b/torchensemble/voting.py
@@ -92,7 +92,6 @@ def _parallel_fit_per_epoch(
     """Implementation on the VotingClassifier.""", "model"
 )
 class VotingClassifier(BaseClassifier):
-
     def __init__(self, voting_strategy="soft", **kwargs):
         super(VotingClassifier, self).__init__(**kwargs)
 
@@ -302,7 +301,6 @@ class VotingClassifier(BaseClassifier):
     """Implementation on the NeuralForestClassifier.""", "tree_ensmeble_model"
 )
 class NeuralForestClassifier(BaseTreeEnsemble, VotingClassifier):
-
     def __init__(self, voting_strategy="soft", **kwargs):
         super().__init__(**kwargs)
 

--- a/torchensemble/voting.py
+++ b/torchensemble/voting.py
@@ -92,17 +92,52 @@ def _parallel_fit_per_epoch(
     """Implementation on the VotingClassifier.""", "model"
 )
 class VotingClassifier(BaseClassifier):
+
+    def __init__(self, voting_strategy="soft", **kwargs):
+        super(VotingClassifier, self).__init__(**kwargs)
+
+        self._implemented_voting_strategies = ["soft", "hard"]
+
+        if voting_strategy not in self._implemented_voting_strategies:
+            msg = (
+                "Voting strategy {} is not implemented, "
+                "please choose from {}."
+            )
+            raise ValueError(
+                msg.format(
+                    voting_strategy, self._implemented_voting_strategies
+                )
+            )
+
+        self.voting_strategy = voting_strategy
+
     @torchensemble_model_doc(
         """Implementation on the data forwarding in VotingClassifier.""",
         "classifier_forward",
     )
     def forward(self, *x):
         # Average over class distributions from all base estimators.
+
+        # output: (n_estimators, batch_size, n_classes)
         outputs = [
             F.softmax(estimator(*x), dim=1) for estimator in self.estimators_
         ]
-        proba = op.average(outputs)
 
+        if self.voting_strategy == "soft": proba = op.average(outputs)
+
+        elif self.voting_strategy == "hard":
+            # Do hard majority voting
+            # votes: (batch_size)
+            votes = torch.stack(outputs).argmax(dim=2).mode(dim=0)[0]
+            # Set the probability of the most voted class to 1
+            proba = torch.zeros_like(outputs[0])
+            proba.scatter_(1, votes.view(-1, 1), 1)
+
+            # TODO: make sure this is compatible with
+            # predict and evaluate
+
+        # Returns averaged class probabilities for each sample
+        # proba shape: (batch_size, n_classes) 
         return proba
 
     @torchensemble_model_doc(
@@ -167,12 +202,19 @@ class VotingClassifier(BaseClassifier):
         # Utils
         best_acc = 0.0
 
-        # Internal helper function on pesudo forward
+        # Internal helper function on psuedo forward
         def _forward(estimators, *x):
             outputs = [
                 F.softmax(estimator(*x), dim=1) for estimator in estimators
             ]
-            proba = op.average(outputs)
+
+            if self.voting_strategy == "soft": proba = op.average(outputs)
+
+            # Maybe the voting strategy can be packaged as a function?
+            elif self.voting_strategy == "hard":
+                votes = torch.stack(outputs).argmax(dim=2).mode(dim=0)[0]
+                proba = torch.zeros_like(outputs[0])
+                proba.scatter_(1, votes.view(-1, 1), 1)
 
             return proba
 
@@ -409,7 +451,7 @@ class VotingRegressor(BaseRegressor):
         # Utils
         best_loss = float("inf")
 
-        # Internal helper function on pesudo forward
+        # Internal helper function on psuedo forward
         def _forward(estimators, *x):
             outputs = [estimator(*x) for estimator in estimators]
             pred = op.average(outputs)


### PR DESCRIPTION
This is a first start to implementing hard majority voting, as mention in #118.

For a brief description of soft and hard voting, see [sklearn's definition](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.VotingClassifier.html).

> voting{‘hard’, ‘soft’}, default=’hard’
> 
> If ‘hard’, uses predicted class labels for majority rule voting. Else if ‘soft’, predicts the class label based on the argmax of the sums of the predicted probabilities, which is recommended for an ensemble of well-calibrated classifiers.

For hard voting, the vector `proba` returned by the [`forward`](https://github.com/TorchEnsemble-Community/Ensemble-Pytorch/blob/master/torchensemble/voting.py#L99) method of the VotingClassifier class now instead becomes a one-hot vector with a 1 on the class which had the majority of the base_estimators votes. 

Worth considering is that `torch.max` is called in the [`evaluate`](https://github.com/TorchEnsemble-Community/Ensemble-Pytorch/blob/master/torchensemble/_base.py#L284) method which essentially just gets the index of the 1 in `proba` from the `forward` method, which works, but maybe isn't a problem?

Any suggestions for improvements are very welcome!
