### PR TITLE
added map_location to the load function of torchensemble.utils.io

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,3 +1,4 @@
+
 ## Contributors ✨
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
@@ -24,9 +25,6 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/cspsampedro"><img src="https://avatars.githubusercontent.com/u/7384605?v=4?s=100" width="100px;" alt="cspsampedro"/><br /><sub><b>cspsampedro</b></sub></a><br /><a href="#ideas-cspsampedro" title="Ideas, Planning, & Feedback">🤔</a> <a href="https://github.com/TorchEnsemble-Community/Ensemble-Pytorch/commits?author=cspsampedro" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/kiranchari"><img src="https://avatars.githubusercontent.com/u/1838910?v=4?s=100" width="100px;" alt="kiranchari"/><br /><sub><b>kiranchari</b></sub></a><br /><a href="https://github.com/TorchEnsemble-Community/Ensemble-Pytorch/commits?author=kiranchari" title="Documentation">📖</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/nolaurence"><img src="https://avatars.githubusercontent.com/u/53215736?v=4?s=100" width="100px;" alt="nolaurence"/><br /><sub><b>nolaurence</b></sub></a><br /><a href="https://github.com/TorchEnsemble-Community/Ensemble-Pytorch/commits?author=nolaurence" title="Code">💻</a></td>
-    </tr>
-    <tr>
-     <td align="center" valign="top" width="14.28%"><a href="https://github.com/AtiqurRahmanAni"><img src="https://avatars.githubusercontent.com/u/56642339?v=4" width="100px;" alt="Atiqur Rahman"/><br /><sub><b>Atiqur Rahman</b></sub></a><br /><a href="https://github.com/AtiqurRahmanAni/Ensemble-Pytorch/commit/fac612ff31032848f832f773d59c7585b1b63674" title="Code">💻</a></td>
     </tr>
   </tbody>
 </table>

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,4 +1,3 @@
-
 ## Contributors ✨
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
@@ -25,6 +24,9 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/cspsampedro"><img src="https://avatars.githubusercontent.com/u/7384605?v=4?s=100" width="100px;" alt="cspsampedro"/><br /><sub><b>cspsampedro</b></sub></a><br /><a href="#ideas-cspsampedro" title="Ideas, Planning, & Feedback">🤔</a> <a href="https://github.com/TorchEnsemble-Community/Ensemble-Pytorch/commits?author=cspsampedro" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/kiranchari"><img src="https://avatars.githubusercontent.com/u/1838910?v=4?s=100" width="100px;" alt="kiranchari"/><br /><sub><b>kiranchari</b></sub></a><br /><a href="https://github.com/TorchEnsemble-Community/Ensemble-Pytorch/commits?author=kiranchari" title="Documentation">📖</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/nolaurence"><img src="https://avatars.githubusercontent.com/u/53215736?v=4?s=100" width="100px;" alt="nolaurence"/><br /><sub><b>nolaurence</b></sub></a><br /><a href="https://github.com/TorchEnsemble-Community/Ensemble-Pytorch/commits?author=nolaurence" title="Code">💻</a></td>
+    </tr>
+    <tr>
+     <td align="center" valign="top" width="14.28%"><a href="https://github.com/AtiqurRahmanAni"><img src="https://avatars.githubusercontent.com/u/56642339?v=4" width="100px;" alt="Atiqur Rahman"/><br /><sub><b>Atiqur Rahman</b></sub></a><br /><a href="https://github.com/AtiqurRahmanAni/Ensemble-Pytorch/commit/fac612ff31032848f832f773d59c7585b1b63674" title="Code">💻</a></td>
     </tr>
   </tbody>
 </table>

--- a/torchensemble/utils/io.py
+++ b/torchensemble/utils/io.py
@@ -45,7 +45,7 @@ def save(model, save_dir, logger):
     return
 
 
-def load(model, save_dir="./", logger=None):
+def load(model, save_dir="./", map_location=None, logger=None):
     """Implement model deserialization from the specified directory."""
     if not os.path.exists(save_dir):
         raise FileExistsError("`{}` does not exist".format(save_dir))
@@ -67,7 +67,7 @@ def load(model, save_dir="./", logger=None):
     if logger:
         logger.info("Loading the model from `{}`".format(save_dir))
 
-    state = torch.load(save_dir)
+    state = torch.load(save_dir, map_location=map_location)
     n_estimators = state["n_estimators"]
     model_params = state["model"]
     model._criterion = state["_criterion"]


### PR DESCRIPTION
Faced a problem when trying to load models on the CPU. When using `io.load` to load a model if `cuda` is not available, an error occurs. I added `map_location` to the `load` method to solve this issue. Now you can load models on the CPU. You need to do like `io.load(......., map_location=torch.device('cpu'))` if you want to load the model on the CPU.